### PR TITLE
Reduce the default rate limiting parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GoogleSheets"
 uuid = "831f653e-6dbc-49a2-ac93-eebfaa09c6e6"
 authors = ["David R. (Chip) Kent IV <chipkent@cecropiacapital.com>"]
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/client.jl
+++ b/src/client.jl
@@ -13,8 +13,8 @@ export sheets_client
 # limits, without clearly indicating that burstiness is the problem.
 #
 # These defaults seem to work.
-default_rate_limiter_tokens_per_sec = 0.95
-default_rate_limiter_max_tokens = 5
+default_rate_limiter_tokens_per_sec = 0.9
+default_rate_limiter_max_tokens = 4
 default_rate_limiter_read = TokenBucketRateLimiter(default_rate_limiter_tokens_per_sec, default_rate_limiter_max_tokens, default_rate_limiter_max_tokens)
 default_rate_limiter_write = TokenBucketRateLimiter(default_rate_limiter_tokens_per_sec, default_rate_limiter_max_tokens, default_rate_limiter_max_tokens)
 


### PR DESCRIPTION
Reduce the default rate limiting frequency from 0.95/sec to 0.9/sec and the default max tokens from 5 to 4 to avoid observed failures.