### PR TITLE
Multi-OS support for build

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "2.0.1"
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
-Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"

--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ Key functions:
 
 To install:
 
-    ```
     pkg] add GoogleSheets
     pkg] build GoogleSheets
-    ```
 
 To use:
 1. Create a Google Sheets API token from either the [python quick start reference](https://developers.google.com/sheets/api/quickstart/python) or the [developers console](https://console.developers.google.com/apis/credentials).

--- a/README.md
+++ b/README.md
@@ -44,16 +44,22 @@ Key functions:
 * `format_conditional!`
 * `format_color_gradient!`
 
+## Install
+
 To install:
 
     pkg] add GoogleSheets
     pkg] build GoogleSheets
+
+## Use
 
 To use:
 1. Create a Google Sheets API token from either the [python quick start reference](https://developers.google.com/sheets/api/quickstart/python) or the [developers console](https://console.developers.google.com/apis/credentials).
 2. Place the Google Sheets API `credentials.json` file in `~/.julia/google_sheets/`.
 3. Connect to Google Sheets using `sheets_client`.
 4. See the scripts directory for examples of using the package.
+
+## Example
 
 An example reading data from a Google Sheet.  See `./scripts/example_read.jl`.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Key functions:
 * `format_color_gradient!`
 
 To install:
+
     ```
     pkg] add GoogleSheets
     pkg] build GoogleSheets

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Key functions:
 * `format_conditional!`
 * `format_color_gradient!`
 
+To install:
+    ```
+    pkg] add GoogleSheets
+    pkg] build GoogleSheets
+    ```
+
 To use:
 1. Create a Google Sheets API token from either the [python quick start reference](https://developers.google.com/sheets/api/quickstart/python) or the [developers console](https://console.developers.google.com/apis/credentials).
 2. Place the Google Sheets API `credentials.json` file in `~/.julia/google_sheets/`.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,8 +2,6 @@
 # To run this script:
 # pkg> build GoogleSheets
 
-using Conda
-
-Conda.add_channel("conda-forge")
-Conda.update()
-Conda.add(["google-api-python-client","google-auth-httplib2","google-auth-oauthlib"])
+using PyCall
+@pyimport pip
+pip.main(["install","google-api-python-client","google-auth-httplib2","google-auth-oauthlib","FAIL-HARD"])


### PR DESCRIPTION
PyCall uses different python backends, depending upon the OS.  Change the build process to be more OS independent.